### PR TITLE
"Araxyte venom sack" -> "Araxyte venom sac"

### DIFF
--- a/default-filter.rs2f
+++ b/default-filter.rs2f
@@ -3,8 +3,8 @@ hidden: true
 name: header
 */
 
-/* Built on: Fri Jul  3 14:01:21 UTC 2026 */
-/* Commit: d5bf9dc */
+/* Built on: Fri Jul  3 14:03:04 UTC 2026 */
+/* Commit: 05359d0 */
 /* Repo: Kaqemeex/loot-filters-modules */
 /* Branch: patch-5 */
 meta {
@@ -3937,7 +3937,7 @@ enum: [
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack" \
+  "Araxyte venom sac" \
 ]
 
 /*@ define:input:herblore_secondaries

--- a/default-filter.rs2f
+++ b/default-filter.rs2f
@@ -3,8 +3,8 @@ hidden: true
 name: header
 */
 
-/* Built on: Fri Jul  3 14:03:04 UTC 2026 */
-/* Commit: 05359d0 */
+/* Built on: Fri Jul  3 14:07:27 UTC 2026 */
+/* Commit: 64fd0da */
 /* Repo: Kaqemeex/loot-filters-modules */
 /* Branch: patch-5 */
 meta {
@@ -17734,7 +17734,7 @@ name: Constants
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack", \
+  "Araxyte venom sac", \
 ]
 
 #define CONST_AMMO_STANDARD_ARROWS_LIST [ \

--- a/default-filter.rs2f
+++ b/default-filter.rs2f
@@ -3,10 +3,10 @@ hidden: true
 name: header
 */
 
-/* Built on: Sun Jun 14 17:05:14 UTC 2026 */
-/* Commit: 56c4e5c */
-/* Repo: typical-whack/loot-filters-modules */
-/* Branch: main */
+/* Built on: Fri Jul  3 14:01:21 UTC 2026 */
+/* Commit: d5bf9dc */
+/* Repo: Kaqemeex/loot-filters-modules */
+/* Branch: patch-5 */
 meta {
     name = "[default: Joe's filter]";
     description = "Offers an original color scheme with extensive support for category-based styling/filtering.";
@@ -3891,7 +3891,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_HIDE [ \
@@ -3929,7 +3929,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_SHOW [ \

--- a/filter.rs2f
+++ b/filter.rs2f
@@ -3,8 +3,8 @@ hidden: true
 name: header
 */
 
-/* Built on: Fri Jul  3 14:01:21 UTC 2026 */
-/* Commit: d5bf9dc */
+/* Built on: Fri Jul  3 14:03:04 UTC 2026 */
+/* Commit: 05359d0 */
 /* Repo: Kaqemeex/loot-filters-modules */
 /* Branch: patch-5 */
 meta {
@@ -3937,7 +3937,7 @@ enum: [
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack" \
+  "Araxyte venom sac" \
 ]
 
 /*@ define:input:herblore_secondaries

--- a/filter.rs2f
+++ b/filter.rs2f
@@ -3,10 +3,10 @@ hidden: true
 name: header
 */
 
-/* Built on: Sun Jun 14 17:05:14 UTC 2026 */
-/* Commit: 56c4e5c */
-/* Repo: typical-whack/loot-filters-modules */
-/* Branch: main */
+/* Built on: Fri Jul  3 14:01:21 UTC 2026 */
+/* Commit: d5bf9dc */
+/* Repo: Kaqemeex/loot-filters-modules */
+/* Branch: patch-5 */
 meta {
     name = "Joe's filter";
     description = "Offers an original color scheme with extensive support for category-based styling/filtering.";
@@ -3891,7 +3891,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_HIDE [ \
@@ -3929,7 +3929,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_SHOW [ \

--- a/filter.rs2f
+++ b/filter.rs2f
@@ -3,8 +3,8 @@ hidden: true
 name: header
 */
 
-/* Built on: Fri Jul  3 14:03:04 UTC 2026 */
-/* Commit: 05359d0 */
+/* Built on: Fri Jul  3 14:07:27 UTC 2026 */
+/* Commit: 64fd0da */
 /* Repo: Kaqemeex/loot-filters-modules */
 /* Branch: patch-5 */
 meta {
@@ -17734,7 +17734,7 @@ name: Constants
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack", \
+  "Araxyte venom sac", \
 ]
 
 #define CONST_AMMO_STANDARD_ARROWS_LIST [ \

--- a/modules/constants.rs2f
+++ b/modules/constants.rs2f
@@ -1607,7 +1607,7 @@ name: Constants
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack", \
+  "Araxyte venom sac", \
 ]
 
 #define CONST_AMMO_STANDARD_ARROWS_LIST [ \

--- a/modules/filtering/herblore_secondaries.rs2f
+++ b/modules/filtering/herblore_secondaries.rs2f
@@ -39,7 +39,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_HIDE [ \
@@ -77,7 +77,7 @@ enum: [
   "Nihil dust",
   "Lily of the sands",
   "Aldarium",
-  "Araxyte venom sack"
+  "Araxyte venom sac"
 ]
 */
 #define VAR_SECONDARIES_SHOW [ \

--- a/modules/filtering/herblore_secondaries.rs2f
+++ b/modules/filtering/herblore_secondaries.rs2f
@@ -85,7 +85,7 @@ enum: [
   "Nihil dust", \
   "Lily of the sands", \
   "Aldarium", \
-  "Araxyte venom sack" \
+  "Araxyte venom sac" \
 ]
 
 /*@ define:input:herblore_secondaries


### PR DESCRIPTION
This is actually biologically correct terminology apparently 